### PR TITLE
#4: Enable to specify version

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class NpmAddDependencies {
 
   runNpmShow(dep) {
     return new Promise((resolve) => {
-      npmRun.exec(`npm show ${dep} dist dist-tags`, (err, stdout) => {
+      npmRun.exec(`npm show ${dep} dist-tags`, (err, stdout) => {
         if (!err) {
           const parsed = stdout.match(/latest: '(.*?)'/i);
 
@@ -73,13 +73,8 @@ class NpmAddDependencies {
               console.log(`Processed: ${dep}, latest version: ${parsed[1]}`);
             } else {
               const [depName, depVersion] = dep.split('@');
-              const parsed = stdout.match(/tarball: '(.*?)'/g);
-              if (!parsed) {
-                console.error(`Could not obtain the specified version for: ${dep}. Skip.`);
-              } else {
-                console.log(`Processed: ${depName}, specified version: ${depVersion}`);
-                this.result[depName] = `${depVersion}`;
-              }
+              this.result[depName] = `${depVersion}`;
+              console.log(`Processed: ${depName}, specified version: ${depVersion}`);
             }
           }
         } else {

--- a/index.js
+++ b/index.js
@@ -55,24 +55,23 @@ class NpmAddDependencies {
   };
 
   runNpmShow(dep) {
+    const [depName, depVersion] = dep.split('@');
     return new Promise((resolve) => {
       npmRun.exec(`npm show ${dep} dist-tags`, (err, stdout) => {
         if (!err) {
           const parsed = stdout.match(/latest: '(.*?)'/i);
 
           if (!parsed || undefined === parsed[1]) {
-            if (!dep.includes('@')) {
+            if (undefined === depVersion) {
               console.error(`Could not obtain the latest version for: ${dep}. Skip.`);
             } else {
-              const [depName, depVersion] = dep.split('@');
               console.error(`Could not obtain the specified version for: ${depName}(${depVersion}). Skip.`);
             }
           } else {
-            if (!dep.includes('@')) {
+            if (undefined === depVersion) {
               this.result[dep] = `^${parsed[1]}`;
               console.log(`Processed: ${dep}, latest version: ${parsed[1]}`);
             } else {
-              const [depName, depVersion] = dep.split('@');
               this.result[depName] = `${depVersion}`;
               console.log(`Processed: ${depName}, specified version: ${depVersion}`);
             }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "npm-add-dependencies": "index.js"
   },
   "dependencies": {
-    "npm-run": "^5.0.1"
+    "npm-run": "^5.0.1",
+    "semver": "^6.3.0"
   }
 }


### PR DESCRIPTION
Fixes #4

## Proposed Changes

  - enable `npm-add-dependencies <package>@<version>`

### Note

Not support 'version range'(e.g. `npm install sax@">=0.1.0 <0.2.0"`) currently.